### PR TITLE
Allow explicit nil for #initialize and #attributes=

### DIFF
--- a/lib/informal/model_no_init.rb
+++ b/lib/informal/model_no_init.rb
@@ -9,8 +9,7 @@ module Informal
     end
 
     def attributes=(attrs)
-      return unless attrs.is_a? Hash
-      attrs.each_pair { |name, value| self.send("#{name}=", value) }
+      attrs && attrs.each_pair { |name, value| self.send("#{name}=", value) }
     end
 
     def persisted?

--- a/lib/informal/model_no_init.rb
+++ b/lib/informal/model_no_init.rb
@@ -9,6 +9,7 @@ module Informal
     end
 
     def attributes=(attrs)
+      return unless attrs.is_a? Hash
       attrs.each_pair { |name, value| self.send("#{name}=", value) }
     end
 

--- a/test/model_test_cases.rb
+++ b/test/model_test_cases.rb
@@ -11,6 +11,11 @@ module ModelTestCases
     assert_nil @model.z
   end
 
+  def test_new_with_nil
+    @model = self.poro_class.new(nil)
+    assert_not_nil @model
+  end
+
   def test_persisted
     assert !@model.persisted?
   end

--- a/test/model_test_cases.rb
+++ b/test/model_test_cases.rb
@@ -12,8 +12,7 @@ module ModelTestCases
   end
 
   def test_new_with_nil
-    @model = self.poro_class.new(nil)
-    assert_not_nil @model
+    assert_nothing_raised { self.poro_class.new(nil) }
   end
 
   def test_persisted


### PR DESCRIPTION
Occasionally occurs, like a #new action that does this:

MyThing.new(params[:my_thing])

params might not have any value and return nil.
