### PR TITLE
Added Rails 3.0 support for informal_model_name feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,6 @@ method to override the model name.
       # ...
     end
 
-Note: the `informal_model_name` feature is available only in Rails 3.1 or greater
-(unless somebody back-ports the required API change to 3.0.x).
-
 ## Idiosyncrasies
 
 The standard way that Rails generates ids for new records is to name them like

--- a/lib/informal/model_name.rb
+++ b/lib/informal/model_name.rb
@@ -1,0 +1,13 @@
+if ActiveModel::VERSION::MINOR == 0
+  module Informal
+    class ModelName < ActiveModel::Name
+      def initialize(name)
+        name.instance_eval do
+          def name() self; end
+        end
+        super
+      end
+    end
+  end
+end
+

--- a/lib/informal/model_no_init.rb
+++ b/lib/informal/model_no_init.rb
@@ -1,4 +1,6 @@
 require "active_model"
+require "informal/model_name"
+
 module Informal
   module ModelNoInit
     def self.included(klass)
@@ -13,6 +15,10 @@ module Informal
       if ActiveModel::VERSION::MINOR > 0
         def informal_model_name(name)
           @_model_name = ActiveModel::Name.new(self, nil, name)
+        end
+      else
+        def informal_model_name(name)
+          @_model_name = ModelName.new(name)
         end
       end
     end

--- a/test/model_test_cases.rb
+++ b/test/model_test_cases.rb
@@ -35,11 +35,9 @@ module ModelTestCases
     assert_equal "Poro", @model.class.model_name.human
   end
 
-  if ActiveModel::VERSION::MINOR > 0
-    def test_model_name_override
-      self.poro_class.informal_model_name("Alias")
-      assert_equal "Alias", @model.class.model_name.human
-    end
+  def test_model_name_override
+    self.poro_class.informal_model_name("Alias")
+    assert_equal "Alias", @model.class.model_name.human
   end
 
   def test_validations


### PR DESCRIPTION
Implemented back port of informal_model_name feature for Rails 3.0
