### PR TITLE
Support Active Record 4 and suggest that users switch to using ActiveModel::Model

### DIFF
--- a/informal.gemspec
+++ b/informal.gemspec
@@ -19,7 +19,5 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency('activemodel', "~> 3.0")
-  # s.add_dependency('activemodel', "~> 3.0.0")     # to test w/o 3.1 only features
-  # s.add_dependency('activemodel', "~> 3.1.0.rc4") # to test 3.1 only features, ex: informal_model_name
+  s.add_dependency('activemodel', ">= 3.0")
 end

--- a/lib/informal/model_no_init.rb
+++ b/lib/informal/model_no_init.rb
@@ -1,7 +1,17 @@
 require "active_model"
+require "active_support/core_ext/module/attribute_accessors"
+
 module Informal
+  mattr_accessor :suggest_active_model_model
+  self.suggest_active_model_model = true
+
   module ModelNoInit
     def self.included(klass)
+      if defined?(ActiveModel::Model) && Informal.suggest_active_model_model
+        ActiveSupport::Deprecation.warn("This version of Active Model has ActiveModel::Model, which is very similar to Informal::Model and Informal::ModelNoInit. Consider including ActiveModel::Model instead. You can silence this warning by setting Informal.suggest_active_model_model = false before you include this module.",
+                                        caller.reject { |s| s.include? "lib/informal" })
+      end
+
       klass.class_eval do
         extend  ActiveModel::Naming
         include ActiveModel::Validations

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,4 +6,6 @@ require "bundler/setup"
 require "informal/model"
 require "informal/model_no_init"
 
+Informal.suggest_active_model_model = false
+
 require File.expand_path(File.join(File.dirname(__FILE__), "model_test_cases"))


### PR DESCRIPTION
This gives app which use Informal an easy upgrade path to Rails 4.
